### PR TITLE
fix unused variables

### DIFF
--- a/cad/plate.scad
+++ b/cad/plate.scad
@@ -30,8 +30,7 @@ top_wide=43;
 
 // insert hole, can be adjusted depending on the size of your insert
 // or if you use autotaping screws
-insert_diameter=3.2;
-insert_height=4.6;
+insert_diameter=4;
 
 module one_side_key_placement(side, nb_c, nb_r, nb_t) {
      translate([side * hand_spacing/2,0,0]) rotate([0,0,side * hand_angle/2]) {
@@ -150,7 +149,7 @@ module case() {
           }
           // screw holes
           screw_placement() {
-               translate([0, 0, -thickness]) cylinder(d=4, h=4*2, center=true);
+               translate([0, 0, -thickness]) cylinder(d=insert_diameter, h=4*2, center=true);
           }
      }
 }


### PR DESCRIPTION
First of all, thank you for making this public! I just finished building it and love it.

One mistake I mad was that I ordered M2 screws and inserts, because I was confused by the line
```
insert_diameter=3.2;
```
This diameter actually matches the M2 inserts. But the variable isn't even used. So I fixed it, which should prevent others from making the same mistake as me and allow the advertised customization.

(the variable `insert_height` was also unused)

Btw. is there any way to tip you? Have you considered setting up a GitHub sponsor thingy?